### PR TITLE
Fix the strip number determination

### DIFF
--- a/src/MuNtupleGEMStandAloneMuonFiller.cc
+++ b/src/MuNtupleGEMStandAloneMuonFiller.cc
@@ -428,7 +428,7 @@ void MuNtupleGEMStandAloneMuonFiller::fill(const edm::Event & ev)
                   m_propagated_layer.push_back(gem_id.layer());
                   m_propagated_chamber.push_back(gem_id.chamber());
                   m_propagated_etaP.push_back(gem_id.roll());
-                  m_propagated_strip.push_back(eta_partition->strip(dest_local_pos));
+                  m_propagated_strip.push_back(eta_partition->strip(local_point));
 
                   m_propagatedGlb_x.push_back(dest_global_pos.x());
                   m_propagatedGlb_y.push_back(dest_global_pos.y());


### PR DESCRIPTION
From the commit message:

> The GEMEtaPartition::strip() function can compute the strip number, which requires local coordinates in the eta partition frame of reference. Previously the local coordinates were provided in the chamber frame of reference - with GEMChamber::toLocal() -, leading to an incorrect derivation of the strip number. This commit ensures the right frame of reference is used - using the local point given by GEMEtaPartition::toLocal().

Tested on relatively recent runs.

Before:

![image](https://github.com/gem-dpg-pfa/MuonDPGNTuples/assets/33247723/198f5ee7-37e4-44a2-a045-0292697164fa)

After:

![image](https://github.com/gem-dpg-pfa/MuonDPGNTuples/assets/33247723/4bca9098-c082-4f67-8b40-b787ffdef9b3)